### PR TITLE
feature: Add text_to_gpt functionality and class to facilitate sending speech-converted text as questions to GPT

### DIFF
--- a/lib/backend/text_to_gpt_service.dart
+++ b/lib/backend/text_to_gpt_service.dart
@@ -1,0 +1,49 @@
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class text_to_gpt_service {
+
+  static final String _apiKey = dotenv.env['CHATGPT_KEY']!;
+  static const String _apiUrl = 'https://api.openai.com/v1/chat/completions';
+
+  Future<String> send_to_GPT(String wordsSpoken, String type) async {
+
+    print('Sending to ChatGPT: $wordsSpoken');
+    print('Type: $type');
+
+    if (wordsSpoken.isEmpty) return '';
+
+    var headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $_apiKey',
+    };
+
+    var body;
+    if (type == "talk") {
+      body = json.encode({
+        "model": "gpt-4",
+        "messages": [
+          {"role": "system", "content": "You are a friendly personal assistant, and your responses will be relatively more concise, more like a conversation."},
+          {"role": "user", "content": wordsSpoken}
+        ],
+        "max_tokens": 100,
+        "temperature": 0.7,
+      });
+    } else {
+      //other types of messages
+      return '';
+    }
+
+    var response = await http.post(Uri.parse(_apiUrl), headers: headers, body: body);
+
+    if (response.statusCode == 200) {
+      var jsonResponse = json.decode(response.body);
+      var generatedText = jsonResponse['choices'][0]['message']['content'];
+      return generatedText.trim();
+    } else {
+      print('Request failed with status: ${response.statusCode}.');
+      return '';
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -717,6 +717,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -753,26 +777,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -833,10 +857,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:

--- a/test/unit/text_to_gpt_test.dart
+++ b/test/unit/text_to_gpt_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jarvis/backend/text_to_gpt_service.dart';
+
+
+void main() {
+  group('ChatGPTService', () {
+    test('sendToChatGPT returns generated text when request is successful',
+        () async {
+      final chatGPTService = text_to_gpt_service();
+
+      final result = await chatGPTService.send_to_GPT('Hello', 'talk');
+
+      expect(result, isA<String>());
+      expect(result, isNotEmpty);
+    });
+
+    test('sendToChatGPT returns empty string when input is empty', () async {
+      final chatGPTService = text_to_gpt_service();
+
+      final result = await chatGPTService.send_to_GPT('', 'talk');
+
+      expect(result, equals(''));
+    });
+
+    test('sendToChatGPT returns empty string when type is not "talk"',
+        () async {
+      final chatGPTService = text_to_gpt_service();
+
+      final result = await chatGPTService.send_to_GPT('Hello', 'other');
+
+      expect(result, equals(''));
+    });
+  });
+}


### PR DESCRIPTION
fix: Add text_to_gpt functionality and class to facilitate sending speech-converted text as questions to GPT

This commit creates the text_to_gpt_service.dart file and selects the corresponding response format based on the type class. It also adds unit tests to verify whether replies can be obtained from GPT in multiple ways.

* fix: Add text_to_gpt_service.dart file in lib/backend
* fix: Add gpt_test.dart file in test/unit for testing
* fix: Create processing() function in lib/home.dart and add UI design in _buildTranscriptionText() to handle calling the GPT method and displaying the response below the button

addresses #36